### PR TITLE
Simplify interface

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,14 +22,14 @@ import rvc.lib.zluda
 
 # Import Tabs
 from tabs.inference.inference import inference_tab
-from tabs.train.train import train_tab
-from tabs.extra.extra import extra_tab
-from tabs.report.report import report_tab
-from tabs.download.download import download_tab
-from tabs.tts.tts import tts_tab
-from tabs.voice_blender.voice_blender import voice_blender_tab
-from tabs.plugins.plugins import plugins_tab
-from tabs.settings.settings import settings_tab
+# from tabs.train.train import train_tab
+# from tabs.extra.extra import extra_tab
+# from tabs.report.report import report_tab
+# from tabs.download.download import download_tab
+# from tabs.tts.tts import tts_tab
+# from tabs.voice_blender.voice_blender import voice_blender_tab
+# from tabs.plugins.plugins import plugins_tab
+# from tabs.settings.settings import settings_tab
 
 # Run prerequisites
 from core import run_prerequisites_script
@@ -70,7 +70,7 @@ with gr.Blocks(
     gr.Markdown("# Applio")
     gr.Markdown(
         i18n(
-            "A simple, high-quality voice conversion tool focused on ease of use and performance."
+            "A simple, high-quality voice conversion tool with a streamlined interface."
         )
     )
     gr.Markdown(
@@ -78,32 +78,34 @@ with gr.Blocks(
             "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
         )
     )
+    gr.Markdown(i18n("Advanced tools are now located inside the inference tab."))
     with gr.Tab(i18n("Inference")):
         inference_tab()
 
-    with gr.Tab(i18n("Training")):
-        train_tab()
+    # The following tabs have been removed to simplify the interface.
+    # with gr.Tab(i18n("Training")):
+    #     train_tab()
 
-    with gr.Tab(i18n("TTS")):
-        tts_tab()
+    # with gr.Tab(i18n("TTS")):
+    #     tts_tab()
 
-    with gr.Tab(i18n("Voice Blender")):
-        voice_blender_tab()
+    # with gr.Tab(i18n("Voice Blender")):
+    #     voice_blender_tab()
 
-    with gr.Tab(i18n("Plugins")):
-        plugins_tab()
+    # with gr.Tab(i18n("Plugins")):
+    #     plugins_tab()
 
-    with gr.Tab(i18n("Download")):
-        download_tab()
+    # with gr.Tab(i18n("Download")):
+    #     download_tab()
 
-    with gr.Tab(i18n("Report a Bug")):
-        report_tab()
+    # with gr.Tab(i18n("Report a Bug")):
+    #     report_tab()
 
-    with gr.Tab(i18n("Extra")):
-        extra_tab()
+    # with gr.Tab(i18n("Extra")):
+    #     extra_tab()
 
-    with gr.Tab(i18n("Settings")):
-        settings_tab()
+    # with gr.Tab(i18n("Settings")):
+    #     settings_tab()
 
     gr.Markdown(
         """

--- a/tabs/inference/inference.py
+++ b/tabs/inference/inference.py
@@ -15,6 +15,9 @@ from assets.i18n.i18n import I18nAuto
 
 from rvc.lib.utils import format_title
 from tabs.settings.sections.restart import stop_infer
+from tabs.voice_blender.voice_blender import voice_blender_tab
+from tabs.extra.extra import extra_tab
+from tabs.settings.settings import settings_tab
 
 i18n = I18nAuto()
 
@@ -2158,3 +2161,12 @@ def inference_tab():
         inputs=[],
         outputs=[convert_button_batch, stop_button],
     )
+
+    with gr.Accordion(i18n("Voice Blender"), open=False):
+        voice_blender_tab()
+
+    with gr.Accordion(i18n("Extra Tools"), open=False):
+        extra_tab()
+
+    with gr.Accordion(i18n("Settings"), open=False):
+        settings_tab()


### PR DESCRIPTION
## Summary
- leave only the Inference tab visible
- mention that advanced tools now live inside the Inference tab
- expose Voice Blender, Extra and Settings inside the Inference tab via accordions

## Testing
- `python -m py_compile app.py tabs/inference/inference.py`

------
https://chatgpt.com/codex/tasks/task_e_6848a3468350832bac70e2acbcde3f18