### PR TITLE
Simplify inference UI with batch mode toggle

### DIFF
--- a/tabs/inference/inference.py
+++ b/tabs/inference/inference.py
@@ -391,8 +391,9 @@ def inference_tab():
                 outputs=[index_file],
             )
 
-    # Single inference tab
-    with gr.Tab(i18n("Single")):
+    batch_mode = gr.Checkbox(label="Batch Mode", value=False)
+
+    with gr.Column(visible=True) as single_group:
         with gr.Column():
             upload_audio = gr.Audio(
                 label=i18n("Upload Audio"), type="filepath", editable=False
@@ -1030,8 +1031,7 @@ def inference_tab():
             )
             vc_output2 = gr.Audio(label=i18n("Export Audio"))
 
-    # Batch inference tab
-    with gr.Tab(i18n("Batch")):
+    with gr.Column(visible=False) as batch_group:
         with gr.Row():
             with gr.Column():
                 input_folder_batch = gr.Textbox(
@@ -1959,6 +1959,11 @@ def inference_tab():
         fn=change_choices,
         inputs=[model_file],
         outputs=[model_file, index_file, audio, sid, sid_batch],
+    )
+    batch_mode.change(
+        fn=lambda m: (gr.update(visible=not m), gr.update(visible=m)),
+        inputs=[batch_mode],
+        outputs=[single_group, batch_group],
     )
     audio.change(
         fn=output_path_fn,


### PR DESCRIPTION
## Summary
- merge single and batch inference into one column
- add Batch Mode checkbox to toggle between single and batch views
- hide/show appropriate groups when checkbox is toggled

## Testing
- `python -m py_compile tabs/inference/inference.py`

------
https://chatgpt.com/codex/tasks/task_e_6848a4901160832b87fd0c7f720891b4