### PR TITLE
Move pitch slider outside advanced settings

### DIFF
--- a/assets/i18n/languages/es_ES.json
+++ b/assets/i18n/languages/es_ES.json
@@ -127,7 +127,7 @@
   "Clean Strength": "Fuerza limpia",
   "Enable formant shifting. Used for male to female and vice-versa convertions.": "Habilite el cambio de formantes. Se utiliza para conversiones de macho a hembra y viceversa.",
   "Browse presets for formanting": "Examinar los ajustes preestablecidos para el formante",
-  "Pitch": "Alquitrán",
+  "Pitch": "Tono - Alquitrán",
   "Set the clean-up level to the audio you want, the more you increase it the more it will clean up, but it is possible that the audio will be more compressed.": "Establezca el nivel de limpieza en el audio que desee, cuanto más lo aumente, más se limpiará, pero es posible que el audio esté más comprimido.",
   "Default value is 1.0": "El valor predeterminado es 1.0",
   "Presets are located in /assets/formant_shift folder": "Los ajustes preestablecidos se encuentran en la carpeta /assets/formant_shift",

--- a/tabs/inference/inference.py
+++ b/tabs/inference/inference.py
@@ -408,6 +408,18 @@ def inference_tab():
                     allow_custom_value=True,
                 )
 
+            pitch = gr.Slider(
+                minimum=-24,
+                maximum=24,
+                step=1,
+                label=i18n("Pitch"),
+                info=i18n(
+                    "Set the pitch of the audio, the higher the value, the higher the pitch."
+                ),
+                value=0,
+                interactive=True,
+            )
+
         with gr.Accordion(i18n("Advanced Settings"), open=False):
             with gr.Column():
                 clear_outputs_infer = gr.Button(
@@ -863,17 +875,6 @@ def inference_tab():
                                 placeholder=i18n("Enter preset name"),
                             )
                             export_button = gr.Button(i18n("Export Preset"))
-                    pitch = gr.Slider(
-                        minimum=-24,
-                        maximum=24,
-                        step=1,
-                        label=i18n("Pitch"),
-                        info=i18n(
-                            "Set the pitch of the audio, the higher the value, the higher the pitch."
-                        ),
-                        value=0,
-                        interactive=True,
-                    )
                     index_rate = gr.Slider(
                         minimum=0,
                         maximum=1,
@@ -1052,6 +1053,19 @@ def inference_tab():
                     value=os.path.join(now_dir, "assets", "audios"),
                     interactive=True,
                 )
+
+            pitch_batch = gr.Slider(
+                minimum=-24,
+                maximum=24,
+                step=1,
+                label=i18n("Pitch"),
+                info=i18n(
+                    "Set the pitch of the audio, the higher the value, the higher the pitch."
+                ),
+                value=0,
+                interactive=True,
+            )
+
         with gr.Accordion(i18n("Advanced Settings"), open=False):
             with gr.Column():
                 clear_outputs_batch = gr.Button(
@@ -1495,17 +1509,6 @@ def inference_tab():
                                 placeholder=i18n("Enter preset name"),
                             )
                             export_button = gr.Button(i18n("Export Preset"))
-                    pitch_batch = gr.Slider(
-                        minimum=-24,
-                        maximum=24,
-                        step=1,
-                        label=i18n("Pitch"),
-                        info=i18n(
-                            "Set the pitch of the audio, the higher the value, the higher the pitch."
-                        ),
-                        value=0,
-                        interactive=True,
-                    )
                     index_rate_batch = gr.Slider(
                         minimum=0,
                         maximum=1,


### PR DESCRIPTION
## Summary
- relocate pitch sliders so they appear below audio selection
- update Spanish translation for pitch label

## Testing
- `python -m py_compile app.py core.py tabs/inference/inference.py`

------
https://chatgpt.com/codex/tasks/task_e_6848d1facb2c832ba70e056bfac7d7c2