### PR TITLE
Add logs manager and default ToS acceptance

### DIFF
--- a/assets/i18n/languages/en_US.json
+++ b/assets/i18n/languages/en_US.json
@@ -335,5 +335,7 @@
   "Overlap length (sec)": "Overlap length (sec)",
   "Length of the overlap between slices for 'Simple' method.": "Length of the overlap between slices for 'Simple' method.",
   "Silent training files": "Silent training files",
-  "Adding several silent files to the training set enables the model to handle pure silence in inferred audio files. Select 0 if your dataset is clean and already contains segments of pure silence.": "Adding several silent files to the training set enables the model to handle pure silence in inferred audio files. Select 0 if your dataset is clean and already contains segments of pure silence."
+  "Adding several silent files to the training set enables the model to handle pure silence in inferred audio files. Select 0 if your dataset is clean and already contains segments of pure silence.": "Adding several silent files to the training set enables the model to handle pure silence in inferred audio files. Select 0 if your dataset is clean and already contains segments of pure silence.",
+  "Model Folder Creator": "Model Folder Creator",
+  "Create Log Folder": "Create Log Folder"
 }

--- a/assets/i18n/languages/es_ES.json
+++ b/assets/i18n/languages/es_ES.json
@@ -321,5 +321,7 @@
   "Model Author Name": "Nombre del autor del modelo",
   "Select the speaker ID to use for the conversion.": "Seleccione el ID de altavoz que se utilizará para la conversión.",
   "Set the autotune strength - the more you increase it the more it will snap to the chromatic grid.": "Establezca la intensidad del ajuste automático: cuanto más lo aumente, más se ajustará a la cuadrícula cromática.",
-  "The name that will appear in the model information.": "El nombre que aparecerá en la información del modelo."
+  "The name that will appear in the model information.": "El nombre que aparecerá en la información del modelo.",
+  "Model Folder Creator": "Creador de carpetas de modelo",
+  "Create Log Folder": "Crear carpeta de logs"
 }

--- a/tabs/inference/inference.py
+++ b/tabs/inference/inference.py
@@ -18,6 +18,7 @@ from tabs.settings.sections.restart import stop_infer
 from tabs.voice_blender.voice_blender import voice_blender_tab
 from tabs.extra.extra import extra_tab
 from tabs.settings.settings import settings_tab
+from tabs.log_manager.log_manager import log_manager_tab
 
 i18n = I18nAuto()
 
@@ -1021,7 +1022,7 @@ def inference_tab():
             info=i18n(
                 "Please ensure compliance with the terms and conditions detailed in [this document](https://github.com/IAHispano/Applio/blob/main/TERMS_OF_USE.md) before proceeding with your inference."
             ),
-            value=False,
+            value=True,
             interactive=True,
         )
 
@@ -1641,7 +1642,7 @@ def inference_tab():
             info=i18n(
                 "Please ensure compliance with the terms and conditions detailed in [this document](https://github.com/IAHispano/Applio/blob/main/TERMS_OF_USE.md) before proceeding with your inference."
             ),
-            value=False,
+            value=True,
             interactive=True,
         )
         convert_button_batch = gr.Button(i18n("Convert"))
@@ -2181,6 +2182,8 @@ def inference_tab():
             with gr.TabItem(i18n("Extra Tools")):
                 with gr.Tabs():
                     extra_tab()
+            with gr.TabItem(i18n("Model Folder Creator")):
+                log_manager_tab()
             with gr.TabItem(i18n("Settings")):
                 with gr.Tabs():
                     settings_tab()

--- a/tabs/log_manager/log_manager.py
+++ b/tabs/log_manager/log_manager.py
@@ -1,0 +1,56 @@
+import os
+import shutil
+import gradio as gr
+
+from assets.i18n.i18n import I18nAuto
+
+i18n = I18nAuto()
+
+now_dir = os.getcwd()
+
+
+def create_log_folder(folder_name, files):
+    if not folder_name:
+        return "Folder name must not be empty."
+
+    folder_name = os.path.basename(folder_name)
+    target_folder = os.path.join(now_dir, "logs", folder_name)
+
+    os.makedirs(target_folder, exist_ok=True)
+
+    if files:
+        for f in files:
+            shutil.move(f, os.path.join(target_folder, os.path.basename(f)))
+
+    return f"Files moved to folder {target_folder}"
+
+
+def log_manager_tab():
+    gr.Markdown(i18n("## Model Folder Creator"))
+    gr.Markdown(
+        i18n(
+            "Create or open a folder for a model inside logs and move uploaded files into it."
+        )
+    )
+    with gr.Column():
+        folder_name = gr.Textbox(
+            label=i18n("Model Name"),
+            placeholder=i18n("Enter model name"),
+            value="",
+            interactive=True,
+            max_lines=1,
+        )
+        files = gr.File(
+            label=i18n("Files"), type="filepath", file_count="multiple"
+        )
+        create_button = gr.Button(i18n("Create Log Folder"))
+        output_info = gr.Textbox(
+            label=i18n("Output Information"),
+            info=i18n("The output information will be displayed here."),
+        )
+
+    create_button.click(
+        fn=create_log_folder,
+        inputs=[folder_name, files],
+        outputs=[output_info],
+    )

--- a/tabs/train/train.py
+++ b/tabs/train/train.py
@@ -757,7 +757,7 @@ def train_tab():
             info=i18n(
                 "Please ensure compliance with the terms and conditions detailed in [this document](https://github.com/IAHispano/Applio/blob/main/TERMS_OF_USE.md) before proceeding with your training."
             ),
-            value=False,
+            value=True,
             interactive=True,
         )
         train_output_info = gr.Textbox(

--- a/tabs/tts/tts.py
+++ b/tabs/tts/tts.py
@@ -332,7 +332,7 @@ def tts_tab():
         info=i18n(
             "Please ensure compliance with the terms and conditions detailed in [this document](https://github.com/IAHispano/Applio/blob/main/TERMS_OF_USE.md) before proceeding with your inference."
         ),
-        value=False,
+        value=True,
         interactive=True,
     )
     convert_button = gr.Button(i18n("Convert"))


### PR DESCRIPTION
## Summary
- set the Terms of Use checkbox to checked by default in inference, training and TTS tabs
- introduce a new **Model Folder Creator** tool under Utilities to move uploaded files to a log folder
- add translations for the new feature in English and Spanish

## Testing
- `python -m py_compile tabs/inference/inference.py tabs/train/train.py tabs/tts/tts.py tabs/log_manager/log_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6848d4970a70832b8b6d99acc886b3bd